### PR TITLE
Compatible with Django 1.11

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -74,10 +74,15 @@ class DateTimePicker(DateTimeInput):
             if format and not self.options.get('format') and not self.attrs.get('date-format'):
                 self.options['format'] = self.conv_datetime_format_py2js(format)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, *args, **kwargs):
         if value is None:
             value = ''
-        input_attrs = self.build_attrs(attrs, type=self.input_type, name=name)
+            
+        extra_attrs = dict(
+            type=self.input_type,
+            name=name
+        )
+        input_attrs = self.build_attrs(attrs, extra_attrs)
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
             input_attrs['value'] = force_text(self._format_value(value))


### PR DESCRIPTION
Django 1.11 remove the `**kwargs` and merge it to `build_attrs`, so I put the `type` and `name` to `extra_attrs`.